### PR TITLE
Redirect to index page when file is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ FROM nginx:1.15
 MAINTAINER Filecoin Dev Team
 
 COPY --from=0 /usr/src/app/build /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
This will allow users to copy URLs and deep dive into the block explorer without running into 404s.