### PR TITLE
Block height, nonce, parentWeight, are returned as base10 strings

### DIFF
--- a/src/api/chain.test.js
+++ b/src/api/chain.test.js
@@ -1,7 +1,6 @@
 /* global jest, test, expect */
 
 import api from './api'
-import { decodeBigInt } from './util'
 import Chain from './chain'
 import chainHeadRes from './fixtures/chain.head.json'
 import headBlock from './fixtures/block/zDPWYqFD7pu9A7r1Lb45GKKkaai4NquaRViBMyPfLZHKrW87DRo2.json'
@@ -28,9 +27,9 @@ test('fetchBlock', async () => {
   expect(block).toEqual({
     cid: chainHeadRes[0]['/'],
     ...headBlock,
-    height: decodeBigInt(headBlock.height),
-    nonce: decodeBigInt(headBlock.nonce),
-    parentWeight: decodeBigInt(headBlock.parentWeight),
+    height: Number(headBlock.height),
+    nonce: Number(headBlock.nonce),
+    parentWeight: Number(headBlock.parentWeight),
   })
 
   // expect 2nd call to hit internal cache not the api mock
@@ -38,9 +37,9 @@ test('fetchBlock', async () => {
   expect(block).toEqual({
     cid: chainHeadRes[0]['/'],
     ...headBlock,
-    height: decodeBigInt(headBlock.height),
-    nonce: decodeBigInt(headBlock.nonce),
-    parentWeight: decodeBigInt(headBlock.parentWeight),
+    height: Number(headBlock.height),
+    nonce: Number(headBlock.nonce),
+    parentWeight: Number(headBlock.parentWeight),
   })
 })
 
@@ -55,9 +54,9 @@ test('fetchHeadBlock', async () => {
   expect(block).toEqual({
     cid: chainHeadRes[0]['/'],
     ...headBlock,
-    height: decodeBigInt(headBlock.height),
-    nonce: decodeBigInt(headBlock.nonce),
-    parentWeight: decodeBigInt(headBlock.parentWeight),
+    height: Number(headBlock.height),
+    nonce: Number(headBlock.nonce),
+    parentWeight: Number(headBlock.parentWeight),
   })
 })
 
@@ -76,7 +75,7 @@ test('fetchChain', async () => {
 
   expect(res.length).toBe(pageSize)
   expect(res[0][0].cid).toEqual(chainHeadRes[0]['/'])
-  const height = decodeBigInt(headBlock.height)
+  const height = Number(headBlock.height)
   expect(res[0][0].height).toEqual(height)
   // expect 2 null blocks
   expect(res[1][0]).toEqual({height: height - 1})

--- a/src/api/fixtures/block/zDPWYqFCtf5awkxnZbpurnQFvsrafnv4nJbP8UkAHD8GCf8T2Sz4.json
+++ b/src/api/fixtures/block/zDPWYqFCtf5awkxnZbpurnQFvsrafnv4nJbP8UkAHD8GCf8T2Sz4.json
@@ -6,9 +6,9 @@
       "/": "zDPWYqFD8BEGJK35zgLZuatM2dAMaNoyHKx6J8U2UDD2LiGfFcnd"
     }
   ],
-  "height": "AA==",
-  "nonce": "AA==",
-  "parentWeight": "Mg==",
+  "height": "0",
+  "nonce": "0",
+  "parentWeight": "50",
   "messages": [],
   "stateRoot": {
     "/": "zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9"

--- a/src/api/fixtures/block/zDPWYqFD4uRLT1cJ62HYKp6nembi2NGPyZ4fJ6E3WMS18YjDkQRf.json
+++ b/src/api/fixtures/block/zDPWYqFD4uRLT1cJ62HYKp6nembi2NGPyZ4fJ6E3WMS18YjDkQRf.json
@@ -6,9 +6,9 @@
       "/": "zDPWYqFCtf5awkxnZbpurnQFvsrafnv4nJbP8UkAHD8GCf8T2Sz4"
     }
   ],
-  "height": "AQ==",
-  "nonce": "AQ==",
-  "parentWeight": "Mg==",
+  "height": "1",
+  "nonce": "1",
+  "parentWeight": "50",
   "messages": [],
   "stateRoot": {
     "/": "zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9"

--- a/src/api/fixtures/block/zDPWYqFD7np5ATk5Qn2bT4nv943Ki9Qug2pm2drtnoyXzYQETKS1.json
+++ b/src/api/fixtures/block/zDPWYqFD7np5ATk5Qn2bT4nv943Ki9Qug2pm2drtnoyXzYQETKS1.json
@@ -6,9 +6,9 @@
       "/": "zDPWYqFD4uRLT1cJ62HYKp6nembi2NGPyZ4fJ6E3WMS18YjDkQRf"
     }
   ],
-  "height": "Ag==",
-  "nonce": "Ag==",
-  "parentWeight": "Mg==",
+  "height": "2",
+  "nonce": "2",
+  "parentWeight": "50",
   "messages": [],
   "stateRoot": {
     "/": "zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9"

--- a/src/api/fixtures/block/zDPWYqFD7pu9A7r1Lb45GKKkaai4NquaRViBMyPfLZHKrW87DRo2.json
+++ b/src/api/fixtures/block/zDPWYqFD7pu9A7r1Lb45GKKkaai4NquaRViBMyPfLZHKrW87DRo2.json
@@ -6,9 +6,9 @@
       "/": "zDPWYqFD7np5ATk5Qn2bT4nv943Ki9Qug2pm2drtnoyXzYQETKS1"
     }
   ],
-  "height": "BQ==",
-  "nonce": "Aw=",
-  "parentWeight": "Mg==",
+  "height": "5",
+  "nonce": "3",
+  "parentWeight": "50",
   "messages": [],
   "stateRoot": {
     "/": "zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9"

--- a/src/api/fixtures/block/zDPWYqFD8BEGJK35zgLZuatM2dAMaNoyHKx6J8U2UDD2LiGfFcnd.json
+++ b/src/api/fixtures/block/zDPWYqFD8BEGJK35zgLZuatM2dAMaNoyHKx6J8U2UDD2LiGfFcnd.json
@@ -6,9 +6,9 @@
       "/": "zDPWYqFD7n8g4dJX1WJqPy7X9aPpAidhXyJUbHruSiuiMtpDehkW"
     }
   ],
-  "parentWeight": "Mg==",
-  "height": "CA==",
-  "nonce": "BQ=",
+  "parentWeight": "50",
+  "height": "8",
+  "nonce": "5",
   "messages": [],
   "stateRoot": {
     "/": "zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9"

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -6,7 +6,7 @@ export function mapAllBigInts (obj, keys = KeysForBigInts) {
   if (!obj) return obj
   return mapObj(obj, (key, value) => {
     if (keys.includes(key)) {
-      value = decodeBigInt(value)
+      value = Number(value)
     }
     return [key, value]
   }, { deep: true })


### PR DESCRIPTION
Fix for https://github.com/filecoin-project/go-filecoin/pull/2298